### PR TITLE
Add DMA code support

### DIFF
--- a/src/clj_maxmind_geoip/core.clj
+++ b/src/clj_maxmind_geoip/core.clj
@@ -29,7 +29,7 @@
 (defn lookup-location
   "Lookup location information for an IP address. Only available when querying a GeoIP City database.
   Returns a map of the following location info, or nil if none found:
-  {:country-code, :country-name, :region-code, :region-name, :city, :postal-code, :latitude, :longitude}"
+  {:country-code, :country-name, :region-code, :region-name, :city, :postal-code, :latitude, :longitude, :dma-code}"
   [^String ip]
   (when-let [^com.maxmind.geoip.Location result
              (.getLocation ^com.maxmind.geoip.LookupService @lookup-service ip)]


### PR DESCRIPTION
There are a couple other fields on the object, but they are fairly uncommon (like metro codes, which seem to be a slightly different and substantially less common form of dma code). I added this one as it's necessary for my work. Other attributes can be found in the code here:

https://github.com/maxmind/geoip-api-java/blob/master/src/main/java/com/maxmind/geoip/Location.java
